### PR TITLE
Disable LED in stealth mode

### DIFF
--- a/applications/services/notification/notification_app.c
+++ b/applications/services/notification/notification_app.c
@@ -250,27 +250,34 @@ static void notification_process_notification_message(
             break;
         case NotificationMessageTypeLedRed:
             // store and send on delay or after seq
+            if(!furi_hal_rtc_is_flag_set(FuriHalRtcFlagStealthMode)) {
             led_active = true;
             led_values[0] = notification_message->data.led.value;
             app->led[0].value_last[LayerNotification] = led_values[0];
             reset_mask |= reset_red_mask;
+            }
             break;
         case NotificationMessageTypeLedGreen:
             // store and send on delay or after seq
+            if(!furi_hal_rtc_is_flag_set(FuriHalRtcFlagStealthMode)) {
             led_active = true;
             led_values[1] = notification_message->data.led.value;
             app->led[1].value_last[LayerNotification] = led_values[1];
             reset_mask |= reset_green_mask;
+            }
             break;
         case NotificationMessageTypeLedBlue:
             // store and send on delay or after seq
+            if(!furi_hal_rtc_is_flag_set(FuriHalRtcFlagStealthMode)) {
             led_active = true;
             led_values[2] = notification_message->data.led.value;
             app->led[2].value_last[LayerNotification] = led_values[2];
             reset_mask |= reset_blue_mask;
+            }
             break;
         case NotificationMessageTypeLedBlinkStart:
             // store and send on delay or after seq
+            if(!furi_hal_rtc_is_flag_set(FuriHalRtcFlagStealthMode)) {
             led_active = true;
             furi_hal_light_blink_start(
                 notification_message->data.led_blink.color,
@@ -281,10 +288,13 @@ static void notification_process_notification_message(
             reset_mask |= reset_red_mask;
             reset_mask |= reset_green_mask;
             reset_mask |= reset_blue_mask;
+            }
             break;
         case NotificationMessageTypeLedBlinkColor:
+            if(!furi_hal_rtc_is_flag_set(FuriHalRtcFlagStealthMode)) {
             led_active = true;
             furi_hal_light_blink_set_color(notification_message->data.led_blink.color);
+            }
             break;
         case NotificationMessageTypeLedBlinkStop:
             furi_hal_light_blink_stop();

--- a/applications/settings/notification_settings/notification_settings_app.c
+++ b/applications/settings/notification_settings/notification_settings_app.c
@@ -205,13 +205,20 @@ static NotificationAppSettings* alloc_settings(void) {
         app->notification->settings.display_off_delay_ms, delay_value, DELAY_COUNT);
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, delay_text[value_index]);
-
-    item = variable_item_list_add(
-        app->variable_item_list, "LED Brightness", BACKLIGHT_COUNT, led_changed, app);
-    value_index = value_index_float(
-        app->notification->settings.led_brightness, backlight_value, BACKLIGHT_COUNT);
-    variable_item_set_current_value_index(item, value_index);
-    variable_item_set_current_value_text(item, backlight_text[value_index]);
+    
+    if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagStealthMode)) {
+        item = variable_item_list_add(app->variable_item_list, "LED Brightness", 1, NULL, app);
+        value_index = 0;
+        variable_item_set_current_value_index(item, value_index);
+        variable_item_set_current_value_text(item, "Stealth");
+    } else {
+        item = variable_item_list_add(
+            app->variable_item_list, "LED Brightness", BACKLIGHT_COUNT, led_changed, app);
+        value_index = value_index_float(
+            app->notification->settings.led_brightness, backlight_value, BACKLIGHT_COUNT);
+        variable_item_set_current_value_index(item, value_index);
+        variable_item_set_current_value_text(item, backlight_text[value_index]);
+    }
 
     if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagStealthMode)) {
         item = variable_item_list_add(app->variable_item_list, "Volume", 1, NULL, app);


### PR DESCRIPTION
# What's new

- notification LED is now disabled in stealth mode

# Verification 

- enable stealth mode and run i.e. SubGHz in read mode. LED should be disabled.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
